### PR TITLE
migrate to GWT 2.11.0 and JWT 5.12.17.0

### DIFF
--- a/jwt-tutorial-000/pom.xml
+++ b/jwt-tutorial-000/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jwt</groupId>
   <artifactId>jwt-tutorial-000</artifactId>
-  <version>5.12.1.12</version>
+  <version>5.12.17.0</version>
 
   <description>Getting Started - jadice web toolkit</description>
   <url>https://levigo.de/info/x/cwGABQ</url>
@@ -18,10 +18,10 @@
     <maven.compiler.target>17</maven.compiler.target>
 
     <!-- levigo dependencies -->
-    <jwt.version>5.12.1.14</jwt.version>
+    <jwt.version>5.12.17.0</jwt.version>
 
     <!-- GWT dependencies -->
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.11.0</gwt.version>
   </properties>
 
   <dependencies>
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
+        <version>2.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/jwt-tutorial-001/pom.xml
+++ b/jwt-tutorial-001/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jwt</groupId>
   <artifactId>jwt-tutorial-001</artifactId>
-  <version>5.12.1.12</version>
+  <version>5.12.17.0</version>
 
   <description>Getting Started - jadice web toolkit</description>
   <url>https://levigo.de/info/x/cwGABQ</url>
@@ -18,10 +18,10 @@
     <maven.compiler.target>17</maven.compiler.target>
 
     <!-- levigo dependencies -->
-    <jwt.version>5.12.1.14</jwt.version>
+    <jwt.version>5.12.17.0</jwt.version>
 
     <!-- GWT dependencies -->
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.11.0</gwt.version>
   </properties>
 
   <dependencies>
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
+        <version>2.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/jwt-tutorial-002/pom.xml
+++ b/jwt-tutorial-002/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jwt</groupId>
   <artifactId>jwt-tutorial-002</artifactId>
-  <version>5.12.1.12</version>
+  <version>5.12.17.0</version>
 
   <description>Getting Started - jadice web toolkit</description>
   <url>https://levigo.de/info/x/cwGABQ</url>
@@ -18,10 +18,10 @@
     <maven.compiler.target>17</maven.compiler.target>
 
     <!-- levigo dependencies -->
-    <jwt.version>5.12.1.14</jwt.version>
+    <jwt.version>5.12.17.0</jwt.version>
 
     <!-- GWT dependencies -->
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.11.0</gwt.version>
   </properties>
 
   <dependencies>
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
+        <version>2.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/jwt-tutorial-003/pom.xml
+++ b/jwt-tutorial-003/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jwt</groupId>
   <artifactId>jwt-tutorial-003</artifactId>
-  <version>5.12.1.12</version>
+  <version>5.12.17.0</version>
 
   <description>Getting Started - jadice web toolkit</description>
   <url>https://levigo.de/info/x/cwGABQ</url>
@@ -18,10 +18,10 @@
     <maven.compiler.target>17</maven.compiler.target>
 
     <!-- levigo dependencies -->
-    <jwt.version>5.12.1.14</jwt.version>
+    <jwt.version>5.12.17.0</jwt.version>
 
     <!-- GWT dependencies -->
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.11.0</gwt.version>
   </properties>
 
   <dependencies>
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
+        <version>2.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/jwt-tutorial-004/pom.xml
+++ b/jwt-tutorial-004/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jwt</groupId>
   <artifactId>jwt-tutorial-004</artifactId>
-  <version>5.12.1.12</version>
+  <version>5.12.17.0</version>
 
   <description>Getting Started - jadice web toolkit</description>
   <url>https://levigo.de/info/x/cwGABQ</url>
@@ -18,10 +18,10 @@
     <maven.compiler.target>17</maven.compiler.target>
 
     <!-- levigo dependencies -->
-    <jwt.version>5.12.1.14</jwt.version>
+    <jwt.version>5.12.17.0</jwt.version>
 
     <!-- GWT dependencies -->
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.11.0</gwt.version>
   </properties>
 
   <dependencies>
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
+        <version>2.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/jwt-tutorial-005/pom.xml
+++ b/jwt-tutorial-005/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jwt</groupId>
   <artifactId>jwt-tutorial-005</artifactId>
-  <version>5.12.1.12</version>
+  <version>5.12.17.0</version>
 
   <description>Getting Started - jadice web toolkit</description>
   <url>https://levigo.de/info/x/cwGABQ</url>
@@ -18,10 +18,10 @@
     <maven.compiler.target>17</maven.compiler.target>
 
     <!-- levigo dependencies -->
-    <jwt.version>5.12.1.14</jwt.version>
+    <jwt.version>5.12.17.0</jwt.version>
 
     <!-- GWT dependencies -->
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.11.0</gwt.version>
   </properties>
 
   <dependencies>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
+        <version>2.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/jwt-tutorial-docker/pom.xml
+++ b/jwt-tutorial-docker/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jwt</groupId>
     <artifactId>jwt-tutorial</artifactId>
-    <version>5.12.1.12</version>
+    <version>5.12.17.0</version>
   </parent>
 
   <properties>
@@ -21,10 +21,10 @@
     <maven.compiler.target>11</maven.compiler.target>
 
     <!-- levigo dependencies -->
-    <jwt.version>5.12.1.14</jwt.version>
+    <jwt.version>5.12.17.0</jwt.version>
 
     <!-- GWT dependencies -->
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.11.0</gwt.version>
 
     <!-- Docker image name -->
     <docker.image.name>${project.artifactId}</docker.image.name>
@@ -90,7 +90,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
+        <version>2.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/jwt-tutorial-performancetest/pom.xml
+++ b/jwt-tutorial-performancetest/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<artifactId>jwt-tutorial</artifactId>
 		<groupId>org.jwt</groupId>
-		<version>5.12.1.12</version>
+		<version>5.12.17.0</version>
 	</parent>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jwt</groupId>
   <artifactId>jwt-tutorial</artifactId>
-  <version>5.12.1.12</version>
+  <version>5.12.17.0</version>
   <name>jwt-tutorial</name>
   <description>Getting Started with Jadice Web Toolkit</description>
   <url>https://levigo.de/info/x/54CaBQ</url>


### PR DESCRIPTION
Time for an upgrade again. 

Please note that in order to successfully run the demos, it seems you must always pass the VM Options 
```-Dspring.devtools.restart.enabled=false --add-opens java.base/jdk.internal.loader=ALL-UNNAMED```.

Also, at least in Intellij, the working directory must point to the directory where the pom of the according tutorial lies. So e.g. if you want to run Tutorial 003, you must set the working directory to this projects subdirectory ```jwt-tutorial-003```